### PR TITLE
Fix `render_er` import regression

### DIFF
--- a/eralchemy/__init__.py
+++ b/eralchemy/__init__.py
@@ -1,2 +1,3 @@
 # -*- coding: utf-8 -*-
+from eralchemy.main import render_er
 from eralchemy.version import version as __version__

--- a/eralchemy/main.py
+++ b/eralchemy/main.py
@@ -2,9 +2,6 @@
 from eralchemy.version import version as __version__
 from eralchemy.cst import GRAPH_BEGINNING
 from eralchemy.sqla import metadata_to_intermediary, declarative_to_intermediary, database_to_intermediary
-from pygraphviz.agraph import AGraph
-from sqlalchemy.engine.url import make_url
-from sqlalchemy.exc import ArgumentError
 from eralchemy.helpers import check_args
 from eralchemy.parser import markdown_file_to_intermediary, line_iterator_to_intermediary, ParsingException
 import argparse
@@ -49,6 +46,7 @@ def intermediary_to_dot(tables, relationships, output):
 
 def intermediary_to_schema(tables, relationships, output):
     """ Transforms and save the intermediary representation to the file chosen. """
+    from pygraphviz.agraph import AGraph
     dot_file = _intermediary_to_dot(tables, relationships)
     graph = AGraph()
     graph = graph.from_string(dot_file)
@@ -120,6 +118,9 @@ def all_to_intermediary(filename_or_input, schema=None):
             return line_iterator_to_intermediary(filename_or_input)
 
     # try to read DB URI.
+    from sqlalchemy.engine.url import make_url
+    from sqlalchemy.exc import ArgumentError
+
     try:
         make_url(filename_or_input)
         return database_to_intermediary(filename_or_input, schema=schema)

--- a/eralchemy/sqla.py
+++ b/eralchemy/sqla.py
@@ -5,7 +5,6 @@ This class allow to transform SQLAlchemy metadata to the intermediary syntax.
 
 from eralchemy.models import Relation, Column, Table
 import sys
-from sqlalchemy.exc import CompileError
 
 if sys.version_info[0] == 3:
     unicode = str
@@ -23,6 +22,8 @@ def relation_to_intermediary(fk):
 
 def format_type(typ):
     """ Transforms the type into a nice string representation. """
+    from sqlalchemy.exc import CompileError
+
     try:
         return unicode(typ)
     except CompileError:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,7 @@ Thanks to it's modular architecture, it can be connected to other ORMs/ODMs/OGMs
 
 Every feedback is welcome on the [GitHub issues](https://github.com/Alexis-benoist/eralchemy/issues).
 
-To run the tests, use : `$ py.test`.
+To run the tests, use : `$ py.test`. Some tests require a local postgres database with a schema named test in a database named test all owned by a user named postgres with a password of postgres.
 
 All tested PR are welcome.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,2 @@
-coverage==4.1
-Flask==0.11.1
-Flask-SQLAlchemy==2.1
-itsdangerous==0.24
-Jinja2==2.8
-MarkupSafe==0.23
-pluggy==0.3.1
-psycopg2==2.6.1
-py==1.4.31
 pygraphviz==1.3.1
-pytest==2.9.2
 SQLAlchemy==1.0.13
-tox==2.3.1
-virtualenv==15.0.2
-Werkzeug==0.11.10
-wheel==0.29.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,17 @@
+coverage==4.1
+Flask==0.11.1
+Flask-SQLAlchemy==2.1
+itsdangerous==0.24
+Jinja2==2.8
+jsonschema==2.5.1
+MarkupSafe==0.23
+pluggy==0.3.1
+psycopg2==2.6.1
+py==1.4.31
+pygraphviz==1.3.1
+pytest==2.9.2
+SQLAlchemy==1.0.13
+tox==2.3.1
+virtualenv==15.0.2
+Werkzeug==0.11.10
+wheel==0.29.0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -57,3 +57,7 @@ def test_get_output_mode():
 
     with pytest.raises(ValueError):
         get_output_mode('anything', 'mode')
+
+
+def test_import_render_er():
+    from eralchemy import render_er

--- a/tox.ini
+++ b/tox.ini
@@ -11,5 +11,5 @@ commands =
   test: py.test
   install: pip install .
 deps =
-    test: -rrequirements.txt 
+    test: -rtest_requirements.txt 
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,5 +11,6 @@ commands =
   test: py.test
   install: pip install .
 deps =
-    test: -rtest_requirements.txt 
-
+  test: -rtest_requirements.txt 
+skip_install =
+  install: true


### PR DESCRIPTION
I also added a test to make sure I don't do anything stupid like that again. The second commit makes some opinionated modifications to the testing that would have helped me when I started working on the code. Namely, it separates the test requirements into an idiomatically named file (with a comment about the db requirement) and restricts the testing package to the relevant directory.