### PR TITLE
allow specify all tables to include

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -159,6 +159,14 @@ def check_intermediary_representation_simple_all_table(tables, relationships):
     assert exclude_relation in relationships
 
 
+def check_included_tables_relationships(actual_tables, actual_relationships):
+    assert len(actual_tables) == 2
+    assert parent in actual_tables
+    assert child in actual_tables
+    assert len(actual_relationships) == 1
+    assert relation in actual_relationships
+
+
 def check_excluded_tables_relationships(actual_tables, actual_relationships):
     assert len(actual_tables) == 2
     assert parent in actual_tables

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from eralchemy.main import all_to_intermediary, get_output_mode, intermediary_to_schema,\
-    intermediary_to_dot, intermediary_to_markdown, filter_excludes
-from tests.common import Base, check_excluded_tables_relationships, \
+    intermediary_to_dot, intermediary_to_markdown, filter_includes, filter_excludes
+from tests.common import Base, check_included_tables_relationships, check_excluded_tables_relationships, \
     check_intermediary_representation_simple_table, create_db, markdown, relationships,\
     tables, check_intermediary_representation_simple_all_table
 
@@ -33,6 +33,17 @@ def test_all_to_intermediary_markdown():
 def test_all_to_intermediary_fails():
     with pytest.raises(ValueError):
         all_to_intermediary('plop')
+
+
+def test_filter_includes_no_includes():
+    actual_tables, actual_relationships = filter_includes(tables, relationships, None)
+    assert actual_tables == tables
+    assert actual_relationships == relationships
+
+
+def test_filter_includes_specified():
+    actual_tables, actual_relationships = filter_includes(tables, relationships, ['parent', 'child'])
+    check_included_tables_relationships(actual_tables, actual_relationships)
 
 
 def test_filter_excludes_no_excludes():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -53,7 +53,7 @@ def test_filter_excludes_no_excludes():
 
 
 def test_filter_excludes_specified():
-    actual_tables, actual_relationships = filter_excludes(tables, relationships, 'exclude')
+    actual_tables, actual_relationships = filter_excludes(tables, relationships, ['exclude'])
     check_excluded_tables_relationships(actual_tables, actual_relationships)
 
 


### PR DESCRIPTION
I added a parameter `include=None` in function `render_er` in order to specify all tables to include. This requirement was also asked in #23 .

Changes:
* add function `filter_includes` and test cases for it.
* refactor function `filter_excludes`.
* add parameter `include=None` in function `render_er`. This may be a break change for someone who use `exclude`, `schema` as positional parameters.