### PR TITLE
Fix relation name conflict

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-language: python
+dist: trusty
+sudo: required
 env:
     - TOXENV=py27-test
     - TOXENV=py27-install

--- a/eralchemy/sqla.py
+++ b/eralchemy/sqla.py
@@ -63,6 +63,12 @@ def declarative_to_intermediary(base):
     return metadata_to_intermediary(base.metadata)
 
 
+def name_for_scalar_relationship(base, local_cls, referred_cls, constraint):
+    """ Overriding naming schemes. """
+    name = referred_cls.__name__.lower() + "_ref"
+    return name
+
+
 def database_to_intermediary(database_uri, schema=None):
     """ Introspect from the database (given the database_uri) to create the intermediary representation. """
     from sqlalchemy.ext.automap import automap_base
@@ -74,5 +80,5 @@ def database_to_intermediary(database_uri, schema=None):
         Base.metadata.schema = schema
 
     # reflect the tables
-    Base.prepare(engine, reflect=True)
+    Base.prepare(engine, reflect=True, name_for_scalar_relationship=name_for_scalar_relationship)
     return declarative_to_intermediary(Base)


### PR DESCRIPTION
This pr make it possible to avoid relation name conflict using `automap_base `'s `name_for_scalar_relationship`

- https://bitbucket.org/zzzeek/sqlalchemy/issues/3449/automap_base-fails-on-my-databa