### PR TITLE
Fix #33

### DIFF
--- a/eralchemy/helpers.py
+++ b/eralchemy/helpers.py
@@ -1,9 +1,10 @@
+from __future__ import print_function
 import sys
 
 
 # from https://github.com/mitsuhiko/flask/blob/master/scripts/make-release.py L92
 def fail(message, *args):
-    print >> sys.stderr, 'Error:', message % args
+    print('Error:', message % args, file=sys.stderr)
     sys.exit(1)
 
 

--- a/script/make_release.py
+++ b/script/make_release.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import sys
 from subprocess import Popen, PIPE
@@ -40,12 +41,12 @@ def build_and_upload():
 
 
 def fail(message, *args):
-    print >> sys.stderr, 'Error:', message % args
+    print('Error:', message % args, file=sys.stderr)
     sys.exit(1)
 
 
 def info(message, *args):
-    print >> sys.stderr, message % args
+    print('Error:', message % args, file=sys.stderr)
 
 
 def git_is_clean():


### PR DESCRIPTION
This patch will switch to use `__future__.print_function`.
By this, It will be able to use `print()` function at Python 2.x and 3.x as well.

```
$ python
Python 3.6.3 (default, Oct 10 2017, 01:16:10) 
[GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from eralchemy import helpers
>>> helpers.fail('test')
Error: test
```

```
$ python 
Python 3.6.3 (default, Oct 10 2017, 01:16:10) 
[GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from script import make_release
>>> make_release.info('test')
Error: test
>>> make_release.fail('test')
Error: test
```

```
$ python
Python 2.7.10 (default, Feb  7 2017, 00:08:15) 
[GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from eralchemy import helpers
>>> helpers.fail('test')
Error: test
```

```
$ python
Python 2.7.10 (default, Feb  7 2017, 00:08:15) 
[GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> 
>>> from script import make_release
>>> make_release.info('test')
Error: test
>>> make_release.fail('test')
Error: test
```