### PR TITLE
Support flask-sqlalchemy 2.3+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
 env:
     - TOXENV=test
     - TOXENV=install
+    - TOXENV=flasksqlalchemy
 before_install:
     - sudo apt-get -qq install graphviz > /dev/null
     - travis_retry pip install tox

--- a/eralchemy/main.py
+++ b/eralchemy/main.py
@@ -75,7 +75,9 @@ switch_input_class_to_method = {
     'MetaData': metadata_to_intermediary,
     'DeclarativeMeta': declarative_to_intermediary,
     # For compatibility with Flask-SQLAlchemy
-    '_BoundDeclarativeMeta': declarative_to_intermediary
+    '_BoundDeclarativeMeta': declarative_to_intermediary,
+    # Renamed in Flask-SQLAlchemy 2.3
+    'DefaultMeta': declarative_to_intermediary
 }
 
 # Routes from the mode to the method to transform the intermediary

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,6 +1,5 @@
 coverage==4.1
 Flask==0.11.1
-Flask-SQLAlchemy==2.1
 itsdangerous==0.24
 Jinja2==2.8
 jsonschema==2.5.1

--- a/tox.ini
+++ b/tox.ini
@@ -4,13 +4,17 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = {test,install}
+envlist = {test,install,flasksqlalchemy}
 
 [testenv]
 commands =
   test: py.test
+  flasksqlalchemy: py.test
   install: pip install .
 deps =
   test: -rtest_requirements.txt 
+  test: Flask-SQLAlchemy==2.1
+  flasksqlalchemy: -rtest_requirements.txt 
+  flasksqlalchemy: Flask-SQLAlchemy==2.3
 skip_install =
   install: true


### PR DESCRIPTION
Addresses #32.
`_BoundDeclarativeMeta` was renamed to `DefaultMeta` in
Flask-SQLAlchemy version 2.3.0. See the [Changelog](http://flask-sqlalchemy.pocoo.org/2.3/changelog/#version-2-3-0)