### PR TITLE
switch cardinality labels' positions

### DIFF
--- a/eralchemy/sqla.py
+++ b/eralchemy/sqla.py
@@ -16,8 +16,8 @@ def relation_to_intermediary(fk):
     return Relation(
         right_col=format_name(fk.parent.table.fullname),
         left_col=format_name(fk._column_tokens[1]),
-        right_cardinality='?',
-        left_cardinality='*',
+        right_cardinality='*',
+        left_cardinality='?',
     )
 
 

--- a/example/newsmeme.er
+++ b/example/newsmeme.er
@@ -40,9 +40,9 @@
 [post_tags]
     *post_id {label:"INTEGER"}
     *tag_id {label:"INTEGER"}
-users *--? posts
-posts *--? comments
-users *--? comments
-comments *--? comments
-tags *--? post_tags
-posts *--? post_tags
+users ?--* posts
+posts ?--* comments
+users ?--* comments
+comments ?--* comments
+tags ?--* post_tags
+posts ?--* post_tags

--- a/tests/common.py
+++ b/tests/common.py
@@ -76,8 +76,8 @@ child_parent_id = ERColumn(
 relation = Relation(
     right_col=u'parent',
     left_col=u'child',
-    right_cardinality='*',
-    left_cardinality='?',
+    right_cardinality='?',
+    left_cardinality='*',
 )
 
 exclude_id = ERColumn(
@@ -94,8 +94,8 @@ exclude_parent_id = ERColumn(
 exclude_relation = Relation(
     right_col=u'parent',
     left_col=u'exclude',
-    right_cardinality='*',
-    left_cardinality='?',
+    right_cardinality='?',
+    left_cardinality='*',
 )
 
 relationships = [relation, exclude_relation]
@@ -128,8 +128,8 @@ markdown = \
     [exclude]
         *id {label:"INTEGER"}
         parent_id {label:"INTEGER"}
-    parent *--? child
-    parent *--? exclude
+    parent ?--* child
+    parent ?--* exclude
     """
 
 

--- a/tests/test_intermediary_to_dot.py
+++ b/tests/test_intermediary_to_dot.py
@@ -71,8 +71,8 @@ def test_relation():
     r = relation_re.match(dot)
     assert r.group('l_name') == 'child'
     assert r.group('r_name') == 'parent'
-    assert r.group('l_card') == '{0,1}'
-    assert r.group('r_card') == '0..N'
+    assert r.group('l_card') == '0..N'
+    assert r.group('r_card') == '{0,1}'
 
 
 def assert_table_well_rendered_to_dot(table):

--- a/tests/test_intermediary_to_er.py
+++ b/tests/test_intermediary_to_er.py
@@ -31,7 +31,7 @@ def test_column_to_er():
 
 
 def test_relation():
-    assert relation.to_markdown() in ['parent *--? child', 'child ?--* parent']
+    assert relation.to_markdown() in ['parent ?--* child', 'child *--? parent']
 
 
 def assert_table_well_rendered_to_er(table):


### PR DESCRIPTION
## Issue
see #54 

### Summary
Cardinality labels on relationships labels are drawn in a different order compared to common ER schemes, which causes confusion when interpreting the diagram.

### Solution
Flip cardinality labels for `ForeignKey`-type relations.

## Before
![person-location](https://user-images.githubusercontent.com/7304317/46748102-22cef180-ccb3-11e8-89ee-867fd4b923cc.png)

## After
![person-location](https://user-images.githubusercontent.com/7304317/47011999-876ece00-d143-11e8-9901-de156b4b06eb.png)

In my opinion, this better represents the relationship:
- One or more people can be born in the same location
- A person has at most one known birth location

closes #54 
