### PR TITLE
setup: don't execute the version.py file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,7 @@ except IOError:
 def read_version():
     with open('eralchemy/version.py') as f:
         code = f.readlines()[0]
-    exec(code)
-    assert ('version' in locals())
-    return locals()['version']
+    return code.split("'")[1]
 
 
 setup(


### PR DESCRIPTION
This is breaking the build with Python 3.13:
https://bugzilla.redhat.com/show_bug.cgi?id=2280551