### PR TITLE
Remove support for python < 3.10

### DIFF
--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -35,12 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
-        sqlachemy-version: [""]
-        include:
-          # oldest python/sqlalchemy supported
-          - python-version: "3.8"
-            sqlalchemy-version: "1.4.18"
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     services:
       eralchemy-db:
         image: postgres:alpine
@@ -72,9 +67,9 @@ jobs:
       - name: Install nox
         run: pip install nox
       - name: Test with pytest
-        run: nox -s ci_test -- ${{ matrix.sqlalchemy-version }}
+        run: nox -s ci_test
       - uses: actions/upload-artifact@v4
-        if: ${{ matrix.python-version == '3.10' }}
+        if: ${{ matrix.python-version == '3.12' }}
         with:
           name: coverage
           path: coverage.xml

--- a/eralchemy/main.py
+++ b/eralchemy/main.py
@@ -5,7 +5,6 @@ import logging
 import os
 import re
 import sys
-import typing
 from functools import partial
 from importlib.metadata import PackageNotFoundError, version
 
@@ -309,7 +308,7 @@ def all_to_intermediary(filename_or_input, schema=None):
         raise ValueError(f"Cannot process filename_or_input {input_class_name}: {e}")
 
 
-def get_output_mode(output: typing.Union[str, None], mode: str):
+def get_output_mode(output: str | None, mode: str):
     """From the output name and the mode returns a the function that will transform the intermediary representation to the output."""
     if mode != "auto":
         try:
@@ -397,7 +396,7 @@ def filter_resources(
 
 def render_er(
     input,
-    output: typing.Union[str, None],
+    output: str | None,
     mode="auto",
     include_tables=None,
     include_columns=None,

--- a/eralchemy/parser.py
+++ b/eralchemy/parser.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import ClassVar, Iterator
+from collections.abc import Iterator
 
 from .models import Column, Drawable, Relation, Table
 
@@ -9,7 +9,7 @@ TYPES: list[type[Drawable]] = [Table, Relation, Column]
 
 class ParsingException(Exception):
     base_traceback = "Error on line {line_nb}: {line}\n{error}"
-    hint: ClassVar[str | None] = None
+    hint: str | None = None
 
     @property
     def traceback(self) -> str:

--- a/eralchemy/sqla.py
+++ b/eralchemy/sqla.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 import sqlalchemy as sa
 from sqlalchemy import create_engine

--- a/noxfile.py
+++ b/noxfile.py
@@ -29,8 +29,6 @@ def ci_test(session):
 
     This is used by the CI and can update the version of sqlalchemy with the posargs.
     """
-    version = f"=={session.posargs[0]}" if session.posargs else ""
-    session.install(f"sqlalchemy{version}")
     session.install(".[test]")
     session.run("pytest", "--color=yes", "--cov", "--cov-report=xml", "tests")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers=[
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Database",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
   "sqlalchemy >= 1.4.18"
 ]


### PR DESCRIPTION
This removes support for old python versions which are not supported anymore as of https://devguide.python.org/versions/

Some improvements to type hints are possible with this.