### PR TITLE
fix test errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ repository = "https://github.com/eralchemy/eralchemy"
 [project.optional-dependencies]
 test = [
   "flask-sqlalchemy >= 2.5.1",
-  "psycopg2 >= 2.9.3",
+  "psycopg2-binary >= 2.9.3",
   "pytest >= 7.4.3",
   "pytest-cov",
   "pygraphviz >= 1.9",
@@ -59,9 +59,7 @@ docs = [
 eralchemy = "eralchemy.main:cli"
 
 [tool.pytest]
-testpaths = "tests"
-
-[tool.pytest.ini_options]
+testpaths = ["tests"]
 markers = ["external_db"]
 
 [tool.mypy]


### PR DESCRIPTION
Fixes pytest failing due to updated pyproject conf

Switch to psycopg2-binary as psycopg2 can not be built without pg_config