### PR TITLE
Move `run_graph` to module scope for Python 3.14 compatibility (fixes #158)

### DIFF
--- a/tests/test_intermediary_to_dot.py
+++ b/tests/test_intermediary_to_dot.py
@@ -26,21 +26,21 @@ column_inside = re.compile(
 )
 
 
+def _run_graph(dot):
+    """Runs graphviz to see if the syntax is good."""
+    graph = AGraph()
+    graph = graph.from_string(dot)
+    extension = "png"
+    graph.draw(path="output.png", prog="dot", format=extension)
+    sys.exit(0)
+
+
 # This test needs fixing with move to graphviz
 def assert_is_dot_format(dot):
     """Checks that the dot is usable by graphviz."""
-
     # We launch a process calling graphviz to render the dot. If the exit code is not 0 we assume that the syntax
     # wasn't good
-    def run_graph(dot):
-        """Runs graphviz to see if the syntax is good."""
-        graph = AGraph()
-        graph = graph.from_string(dot)
-        extension = "png"
-        graph.draw(path="output.png", prog="dot", format=extension)
-        sys.exit(0)
-
-    p = Process(target=run_graph, args=(dot,))
+    p = Process(target=_run_graph, args=(dot,))
     p.start()
     p.join()
     assert p.exitcode == 0


### PR DESCRIPTION
Python 3.14 [changed](https://docs.python.org/3/whatsnew/3.14.html#whatsnew314-multiprocessing-start-method) the default process start method to `forkserver` which requires arguments to `Process` to be picklable. `assert_is_dot_format` uses a nested function `run_graph` as the `target` argument, which can't be pickled, causing some tests to fail with Python 3.14. Fix this by moving `run_graph` to the top level of the module.

Fixes #158