### PR TITLE
Stabilize SQLAlchemy foreign key ordering

### DIFF
--- a/eralchemy/sqla.py
+++ b/eralchemy/sqla.py
@@ -84,6 +84,16 @@ def column_to_intermediary(
     )
 
 
+def foreign_key_sort_key(fk: sa.ForeignKey) -> tuple[str, str, str, str]:
+    """Return a stable sort key for SQLAlchemy foreign keys."""
+    return (
+        format_name(fk.parent.table.fullname),
+        format_name(fk.column.table.fullname),
+        format_name(fk.parent.name),
+        format_name(fk.column.name),
+    )
+
+
 def table_to_intermediary(table: sa.Table) -> Table:
     """Transform an SQLAlchemy Table object to its intermediary representation."""
     return Table(
@@ -100,7 +110,8 @@ def metadata_to_intermediary(
     relationships = [
         relation_to_intermediary(fk)
         for table in metadata.tables.values()
-        for fk in table.foreign_keys
+        # Normalize FK iteration so rendered output stays deterministic across processes.
+        for fk in sorted(table.foreign_keys, key=foreign_key_sort_key)
     ]
     return tables, relationships
 

--- a/tests/check_deterministic_render.py
+++ b/tests/check_deterministic_render.py
@@ -1,0 +1,81 @@
+"""Script used to check ER rendering determinism across PYTHONHASHSEED values."""
+
+import argparse
+import hashlib
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def build_env(seed: int) -> dict[str, str]:
+    return {
+        "HOME": str(Path.home()),
+        "PATH": os.environ["PATH"],
+        "PYTHONHASHSEED": str(seed),
+        "PYTHONPATH": str(Path(__file__).resolve().parents[1]),
+    }
+
+
+def render_script() -> str:
+    return """
+from sqlalchemy import Column, ForeignKey, String
+from sqlalchemy.orm import declarative_base
+
+from eralchemy.main import render_er
+
+Base = declarative_base()
+
+
+class ParentA(Base):
+    __tablename__ = "parent_a"
+    id = Column(String(), primary_key=True)
+
+
+class ParentB(Base):
+    __tablename__ = "parent_b"
+    id = Column(String(), primary_key=True)
+
+
+class Child(Base):
+    __tablename__ = "child"
+    id = Column(String(), primary_key=True)
+    b_id = Column(String(), ForeignKey(ParentB.id))
+    a_id = Column(String(), ForeignKey(ParentA.id))
+
+
+out = render_er(Base, output=None, mode="dot")
+print(out.decode() if isinstance(out, bytes) else out)
+"""
+
+
+def cli() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--seeds",
+        type=int,
+        default=10,
+        help="Number of hash seeds to test.",
+    )
+    args = parser.parse_args()
+
+    outputs: dict[str, list[int]] = {}
+    script = render_script()
+    for seed in range(1, args.seeds + 1):
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            check=True,
+            env=build_env(seed),
+            text=True,
+        )
+        digest = hashlib.sha256(result.stdout.encode("utf-8")).hexdigest()
+        outputs.setdefault(digest, []).append(seed)
+
+    print(f"unique_outputs={len(outputs)}")
+    for digest, seeds in sorted(outputs.items()):
+        print(f"{digest} seeds={seeds}")
+
+
+if __name__ == "__main__":
+    cli()

--- a/tests/test_sqla_to_intermediary.py
+++ b/tests/test_sqla_to_intermediary.py
@@ -1,4 +1,5 @@
 import re
+import subprocess
 
 import pytest
 
@@ -155,3 +156,79 @@ def test_table_names_in_relationships_with_schema(pg_db_uri):
         # Table name in relationship *SHOULD* have a schema
         assert re.match(matcher, r_name) is not None
         assert re.match(matcher, l_name) is not None
+
+
+def test_render_er_dot_is_deterministic_across_hash_seeds():
+    script = """
+tmpdir=$(mktemp -d)
+for seed in 1 2 3 4 5 6 7 8 9 10; do
+    env -i PATH="$PATH" HOME="$HOME" PYTHONPATH="$PWD" PYTHONHASHSEED="$seed" python3 - <<'PY' > "$tmpdir/$seed.txt"
+from sqlalchemy import Column, ForeignKey, String
+from sqlalchemy.orm import declarative_base
+
+from eralchemy.main import render_er
+
+Base = declarative_base()
+
+
+class ParentA(Base):
+    __tablename__ = "parent_a"
+    id = Column(String(), primary_key=True)
+
+
+class ParentB(Base):
+    __tablename__ = "parent_b"
+    id = Column(String(), primary_key=True)
+
+
+class Child(Base):
+    __tablename__ = "child"
+    id = Column(String(), primary_key=True)
+    b_id = Column(String(), ForeignKey(ParentB.id))
+    a_id = Column(String(), ForeignKey(ParentA.id))
+
+
+out = render_er(Base, output=None, mode="dot")
+print(out.decode() if isinstance(out, bytes) else out)
+PY
+done
+sha256sum "$tmpdir"/*.txt | awk '{print $1}' | sort -u | wc -l
+"""
+    result = subprocess.run(
+        ["bash", "-lc", script],
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+    assert result.stdout.strip() == "1"
+
+
+def test_relationships_are_sorted_deterministically():
+    from sqlalchemy import Column, ForeignKey, String
+    from sqlalchemy.orm import declarative_base
+
+    Base = declarative_base()
+
+    class ParentA(Base):
+        __tablename__ = "parent_a"
+        id = Column(String(), primary_key=True)
+
+    class ParentB(Base):
+        __tablename__ = "parent_b"
+        id = Column(String(), primary_key=True)
+
+    class Child(Base):
+        __tablename__ = "child"
+        id = Column(String(), primary_key=True)
+        b_id = Column(String(), ForeignKey(ParentB.id))
+        a_id = Column(String(), ForeignKey(ParentA.id))
+
+    _, relationships = declarative_to_intermediary(Base)
+
+    assert [
+        (relationship.left_table, relationship.left_column, relationship.right_table, relationship.right_column)
+        for relationship in relationships
+    ] == [
+        ("parent_a", "id", "child", "a_id"),
+        ("parent_b", "id", "child", "b_id"),
+    ]

--- a/tests/test_sqla_to_intermediary.py
+++ b/tests/test_sqla_to_intermediary.py
@@ -1,5 +1,4 @@
 import re
-import subprocess
 
 import pytest
 
@@ -156,53 +155,6 @@ def test_table_names_in_relationships_with_schema(pg_db_uri):
         # Table name in relationship *SHOULD* have a schema
         assert re.match(matcher, r_name) is not None
         assert re.match(matcher, l_name) is not None
-
-
-def test_render_er_dot_is_deterministic_across_hash_seeds():
-    script = """
-tmpdir=$(mktemp -d)
-for seed in 1 2 3 4 5 6 7 8 9 10; do
-    env -i PATH="$PATH" HOME="$HOME" PYTHONPATH="$PWD" PYTHONHASHSEED="$seed" python3 - <<'PY' > "$tmpdir/$seed.txt"
-from sqlalchemy import Column, ForeignKey, String
-from sqlalchemy.orm import declarative_base
-
-from eralchemy.main import render_er
-
-Base = declarative_base()
-
-
-class ParentA(Base):
-    __tablename__ = "parent_a"
-    id = Column(String(), primary_key=True)
-
-
-class ParentB(Base):
-    __tablename__ = "parent_b"
-    id = Column(String(), primary_key=True)
-
-
-class Child(Base):
-    __tablename__ = "child"
-    id = Column(String(), primary_key=True)
-    b_id = Column(String(), ForeignKey(ParentB.id))
-    a_id = Column(String(), ForeignKey(ParentA.id))
-
-
-out = render_er(Base, output=None, mode="dot")
-print(out.decode() if isinstance(out, bytes) else out)
-PY
-done
-sha256sum "$tmpdir"/*.txt | awk '{print $1}' | sort -u | wc -l
-"""
-    result = subprocess.run(
-        ["bash", "-lc", script],
-        capture_output=True,
-        check=True,
-        text=True,
-    )
-    assert result.stdout.strip() == "1"
-
-
 def test_relationships_are_sorted_deterministically():
     from sqlalchemy import Column, ForeignKey, String
     from sqlalchemy.orm import declarative_base

--- a/tests/test_sqla_to_intermediary.py
+++ b/tests/test_sqla_to_intermediary.py
@@ -155,6 +155,8 @@ def test_table_names_in_relationships_with_schema(pg_db_uri):
         # Table name in relationship *SHOULD* have a schema
         assert re.match(matcher, r_name) is not None
         assert re.match(matcher, l_name) is not None
+
+
 def test_relationships_are_sorted_deterministically():
     from sqlalchemy import Column, ForeignKey, String
     from sqlalchemy.orm import declarative_base


### PR DESCRIPTION
## Summary
- stabilize SQLAlchemy foreign key iteration before converting relationships to the intermediary representation
- add a regression test that fixes the relationship ordering for a representative multi-FK model
- add a manual verification script for checking DOT determinism across multiple `PYTHONHASHSEED` values

## Why
`metadata_to_intermediary()` currently iterates `table.foreign_keys` directly. In a fresh Python process, that can produce different relationship orders across hash seeds, which leads to unnecessary ER/DOT diffs even when the schema is unchanged.

This change keeps table and column handling as-is and only normalizes foreign key iteration with a stable structural sort key.

## Relation To Other Sorting Work
- This is intentionally limited to the SQLAlchemy conversion path in `sqla.py`.
- It is not meant to define a new global/user-facing relationship sort policy in `main.py`.
- In particular, this is different from #161, which sorts parsed markdown relationships later in the pipeline.
- My understanding is that this fix addresses nondeterministic SQLAlchemy input iteration, while broader relationship sorting policy can still be discussed separately.
- For the same reason, I did not wire this into `sort_mode`: unlike column ordering in #157, this change is input normalization for deterministic conversion, not a user-selectable presentation mode.

## Verification
- `python3 -m pytest -q tests/test_sqla_to_intermediary.py tests/test_sqla_multi_key.py -m 'not external_db'`
- `python3 tests/check_deterministic_render.py --seeds 10`

## Notes
- `tests/check_deterministic_render.py` is a manual verification script and is not part of the automated test suite.
- I placed it under `tests/` because `tests/create_db.py` already exists as a manually-invoked helper script in a similar role.
- That said, I agree this placement may not be ideal long-term, and I’m happy to move or drop it if maintainers would prefer to keep manual verification outside `tests/`.
